### PR TITLE
REPO-3596: Shut down internal APIs

### DIFF
--- a/helm/alfresco-search/templates/_helpers.tpl
+++ b/helm/alfresco-search/templates/_helpers.tpl
@@ -5,6 +5,13 @@ THE TEMPLATES DEFINED BELOW WILL BE USED BY OTHER CHARTS.
 */}}
 
 {{/*
+Get Alfresco Search name
+*/}}
+{{- define "alfresco-search" -}}
+{{- printf "%s-%s-%s" .Release.Name "alfresco-search" "solr" -}}
+{{- end -}}
+
+{{/*
 Get Alfresco Search Host
 */}}
 {{- define "alfresco-search.host" -}}

--- a/helm/alfresco-search/templates/_helpers.tpl
+++ b/helm/alfresco-search/templates/_helpers.tpl
@@ -5,10 +5,11 @@ THE TEMPLATES DEFINED BELOW WILL BE USED BY OTHER CHARTS.
 */}}
 
 {{/*
-Get Alfresco Search name
+Get Alfresco Search Full Name
 */}}
-{{- define "alfresco-search" -}}
-{{- printf "%s-%s-%s" .Release.Name "alfresco-search" "solr" -}}
+{{- define "alfresco-search.fullName" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -28,14 +29,6 @@ Get Alfresco Search Port
 {{/* ======================================================================== */}}
 
 {{/* THE TEMPLATES DEFINED BELOW ARE SUPPOSSED TO BE USED FOR THIS CHART ONLY */}}
-
-{{/*
-Get Alfresco Search Full Name
-*/}}
-{{- define "alfresco-search.fullName" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 
 {{/*
 Get Alfresco Search Internal Port

--- a/helm/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-search/templates/ingress.yaml
@@ -7,6 +7,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: {{ template "alfresco-search" . }}
+    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Alfresco Search Services"
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.whitelist_ips }}
+
 spec:
   rules:
   - http:

--- a/helm/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-search/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 # Defines the ingress for the Alfresco Search (Solr) App
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -14,3 +15,4 @@ spec:
         backend:
           serviceName: {{ template "alfresco-search.fullName" . }}-solr
           servicePort: {{ .Values.service.externalPort }}
+{{- end }}

--- a/helm/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-search/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: {{ template "alfresco-search" . }}
+    nginx.ingress.kubernetes.io/auth-secret: {{ template "alfresco-search.fullName" . }}-solr
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Alfresco Search Services"
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.whitelist_ips }}
 

--- a/helm/alfresco-search/templates/secrets.yaml
+++ b/helm/alfresco-search/templates/secrets.yaml
@@ -8,6 +8,5 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-  # Helm charts do not support as of now to use a hashing algorithm
-  auth: {{ (print "admin:{PLAIN}" (index .Values.ingress.authPass)) | b64enc | quote }}
+  auth: {{ .Values.ingress.basicAuth | quote }}
 {{- end }}

--- a/helm/alfresco-search/templates/secrets.yaml
+++ b/helm/alfresco-search/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "alfresco-search" . }}
+  name: {{ template "alfresco-search.fullName" . }}-solr
   labels:
     app: {{ template "alfresco-search.host" . }}
     release: {{ .Release.Name }}

--- a/helm/alfresco-search/templates/secrets.yaml
+++ b/helm/alfresco-search/templates/secrets.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "alfresco-search" . }}
+  labels:
+    app: {{ template "alfresco-search.host" . }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  # Helm charts do not support as of now to use a hashing algorithm
+  auth: {{ (print "admin:{PLAIN}" (index .Values.ingress.authPass)) | b64enc | quote }}
+{{- end }}

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -28,9 +28,10 @@ ingress:
   enabled: true
   path: /solr
   # Default solr basic auth user/password: admin / admin
-  # You can create your own with htpasswd utilility & encode it with base64
-  # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64`
-  basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
+  # You can create your own with htpasswd utilility & encode it with base640.
+  # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64` # i.e. admin / admin
+  # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
+  basicAuth:
   # Comma separated list of IP CIDR to limit search endpoint over the internet
   whitelist_ips: "0.0.0.0/0"
 # The parent chart will set the values for "repository.host" and "repository.port"

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -27,8 +27,10 @@ service:
 ingress:
   enabled: true
   path: /solr
-  # Solr 'admin' user password
-  authPass: admin
+  # Default solr basic auth user/password: admin / admin
+  # You can create your own with htpasswd utilility & encode it with base64
+  # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64`
+  basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
   # Comma separated list of IP CIDR to limit search endpoint over the internet
   whitelist_ips: "0.0.0.0/0"
 # The parent chart will set the values for "repository.host" and "repository.port"

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -26,7 +26,7 @@ service:
   externalPort: 80
 ingress:
   enabled: true
-  path: /solr4
+  path: /solr
 # The parent chart will set the values for "repository.host" and "repository.port"
 repository: {}
 environment:

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -27,6 +27,10 @@ service:
 ingress:
   enabled: true
   path: /solr
+  # Solr 'admin' user password
+  authPass: admin
+  # Comma separated list of IP CIDR to limit search endpoint over the internet
+  whitelist_ips: "0.0.0.0/0"
 # The parent chart will set the values for "repository.host" and "repository.port"
 repository: {}
 environment:

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -25,7 +25,8 @@ service:
   type: ClusterIP
   externalPort: 80
 ingress:
-  path: /solr
+  enabled: true
+  path: /solr4
 # The parent chart will set the values for "repository.host" and "repository.port"
 repository: {}
 environment:


### PR DESCRIPTION
- Make `/solr` external access configurable with a boolean
- Add basic auth to guard `/solr` but without any default user or password so end user creates it accordingly
- Add functionality to be able to limit `/solr` to a specific ip lists 