### PR TITLE
build helm chart locally faster

### DIFF
--- a/helm/alfresco-search/.cmd/new-version.sh
+++ b/helm/alfresco-search/.cmd/new-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [ $# -lt 1 ]; then
+   echo "Please pass the current version as first parameter so I can generate the new version!" 
+   echo "Example: $ $0 0.0.2 #will generate 0.0.3" 
+   exit 1 
+fi
+set -e
+echo $1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}'

--- a/helm/alfresco-search/Makefile
+++ b/helm/alfresco-search/Makefile
@@ -1,0 +1,42 @@
+
+OS := $(shell uname)
+
+NAME := $(shell sed -n 's/^name: //p' Chart.yaml)
+CURRENT_VERSION := $(shell sed -n 's/^version: //p' Chart.yaml)
+RELEASE_VERSION := $(shell .cmd/new-version.sh $(CURRENT_VERSION))
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+# this will clean build and package your helm chart
+# it will also save it to your local helm repository
+# you can serve it using: $ helm serve
+package: build	
+	helm init --client-only
+	helm package .	
+	helm search local/alfresco-search -l
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml	
+	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+
+push-tag:	
+	git add --all
+	git commit -m "release alfresco-search v.$(RELEASE_VERSION) chart" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)


### PR DESCRIPTION
**Story**

_As a DevOps engineer
I want to be able to build my alfresco-chart from my code-repository with one command
So that I can release it faster_

Features:
* build the chart (running: make)
* package it (running: make package)
* even tag the release (running: make tag) or push to git (running: make push-tag)

The release version is auto-generated