### PR TITLE
fix: externalize values for init container image repository and tag 

### DIFF
--- a/helm/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-search/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
       initContainers:
         - name: init-db
-          image: busybox
+          image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}
           # command to allow solr to write to EFS volume. Details: https://issues.alfresco.com/jira/browse/DEPLOY-419
           command: ["sh", "-c", "chown -R 33007:33007 {{ .Values.persistence.search.data.mountPath }}"]
           volumeMounts:

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -15,6 +15,10 @@ searchServicesImage:
   tag: "1.3.0.4"
   pullPolicy: &searchDockerImagePullPolicy Always
   internalPort: &searchDockerImageInternalPort 8983
+initContainer:
+  image:
+    repository: busybox
+    tag: latest  
 insightEngineImage:
   repository: quay.io/alfresco/insight-engine
   tag: "1.1.0.1"


### PR DESCRIPTION
This PR externalizes init containers Docker image repository and tag values for Solr deployment. This is needed to be able to override image repository for deployments that use organization's private Docker registry instead of public Docker Hub or Alfresco Quay.io.