### PR TITLE
REPO-4569: Use registryPullSecrets as a global value so it can get override from a parent Alfresco Helm chart(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following table lists the configurable parameters of the [Alfresco Search](.
 Parameter | Description | Default
 --- | --- | ---
 `alfresco-search.type` | Define the type of Alfresco Search to use. Available options: `insight-engine` or `search-services` | `search-services`
-`alfresco-search.registryPullSecrets` | This property does not have to be set if `alfresco-search.type` is not set to `insight-engine` explicitly as the Docker image in [DockerHub](https://hub.docker.com/r/alfresco/alfresco-search-services/tags/) is publicly available| NONE  
+`alfresco-search.global.alfrescoRegistryPullSecrets` | This property does not have to be set if `alfresco-search.type` is not set to `insight-engine` explicitly as the Docker image in [DockerHub](https://hub.docker.com/r/alfresco/alfresco-search-services/tags/) is publicly available| NONE
 `alfresco-search.ingress.enabled` | Enable external access for Alfresco Search Services | `true`
 `alfresco-search.ingress.basicAuth` | if `alfresco-search.ingress.enabled` is `true`, user needs to provide a `base64` encoded `htpasswd` format user name & password (ex: `echo -n "$(htpasswd -nbm solradmin somepassword)"` where `solradmin` is username and `somepassword` is the password) | NONE
 `alfresco-search.ingress.whitelist_ips` | if `ingress.enabled=true`, user can restrict /solr to a list of IP addresses of CIDR notation | `0.0.0.0/0`

--- a/helm/alfresco-search/Chart.yaml
+++ b/helm/alfresco-search/Chart.yaml
@@ -11,4 +11,4 @@ keywords:
 name: alfresco-search
 sources:
 - https://github.com/alfresco/alfresco-search-deployment
-version: 1.0.0
+version: 1.0.1

--- a/helm/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-search/templates/deployment.yaml
@@ -25,10 +25,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -6,8 +6,8 @@
 # This is the search provider used by alfresco-content-repository
 replicaCount: 1
 # Define the type of Alfresco Search to use. The default is Alfresco Search Services.
-# The type can be set to use Insight Engine with --set alfresco-search.type="insight-engine",alfresco-search.registryPullSecrets="quay-registry-secret",alfresco-insight-zeppelin.enabled="true"
-# As the Docker Image for Insight Engine is not publicly available the registryPullSecrets has to be set
+# The type can be set to use Insight Engine with --set alfresco-search.type="insight-engine",alfresco-search.global.alfrescoRegistryPullSecrets="quay-registry-secret",alfresco-insight-zeppelin.enabled="true"
+# As the Docker Image for Insight Engine is not publicly available the alfrescoRegistryPullSecrets has to be set
 # More information can be found on https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md
 type: "search-services"
 searchServicesImage:
@@ -69,7 +69,9 @@ livenessProbe:
   timeoutSeconds: 10
 
 # Apply your secret file in k8s environment to access quay.io images (Example: https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md)
-registryPullSecrets: quay-registry-secret
+# Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s)
+global:
+  alfrescoRegistryPullSecret: quay-registry-secret
 
 # Define Affinity and Tolerations used for scheduling SOLR on Pod and PV level
 


### PR DESCRIPTION
- Use `registryPullSecrets` as a global variable so it can be accessed via parent helm chart(s)
- Rename `registryPullSecrets` to `alfrescoRegistryPullSecrets` (to be a bit organisation specific) as recommended
- Bump chart version to `1.0.1`