### PR TITLE
REPO-4659: Bump zepplin helm chart to version 1.0.1

### DIFF
--- a/helm/alfresco-search/requirements.yaml
+++ b/helm/alfresco-search/requirements.yaml
@@ -1,6 +1,6 @@
 # Alfresco Insight Engine brings Alfresco Insight Zeppelin
 dependencies:
 - name: alfresco-insight-zeppelin
-  version: 1.0.0
+  version: 1.0.1
   repository: http://kubernetes-charts.alfresco.com/stable
   condition: alfresco-insight-zeppelin.enabled


### PR DESCRIPTION
- Zepplin helm chart `1.0.1` include changes required for `global` variable used for `alfrescoRegistryPullSecrets` to pull images from a private docker repository