### PR TITLE
Kubernetes 1.16 Compatibility

### DIFF
--- a/helm/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-search/templates/deployment.yaml
@@ -1,5 +1,5 @@
 # Defines the deployment for the Alfresco Search (Solr) App
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "alfresco-search.fullName" . }}-solr
@@ -11,6 +11,9 @@ metadata:
     component: search
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "alfresco-search.fullName" . }}-solr
   template:
     metadata:
       labels:


### PR DESCRIPTION
Replace removed api version `extensions/v1beta1` by `apps/v1` and add required pod selector.