### PR TITLE
REPO-4916 MNT-21041: ACS Helm upgrade to update configuration values does not restart affected pods

### DIFF
--- a/helm/alfresco-search/Chart.yaml
+++ b/helm/alfresco-search/Chart.yaml
@@ -11,4 +11,4 @@ keywords:
 name: alfresco-search
 sources:
 - https://github.com/alfresco/alfresco-search-deployment
-version: 1.0.1
+version: 1.0.2

--- a/helm/alfresco-search/requirements.yaml
+++ b/helm/alfresco-search/requirements.yaml
@@ -1,6 +1,6 @@
 # Alfresco Insight Engine brings Alfresco Insight Zeppelin
 dependencies:
 - name: alfresco-insight-zeppelin
-  version: 1.0.1
+  version: 1.0.2
   repository: http://kubernetes-charts.alfresco.com/stable
   condition: alfresco-insight-zeppelin.enabled

--- a/helm/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-search/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
       labels:
         app: {{ template "alfresco-search.fullName" . }}-solr
         release: {{ .Release.Name }}


### PR DESCRIPTION
- Add k8s annotation checksum/config to trigger pod recreation at helm upgrades if there are changes in the configuration
- https://issues.alfresco.com/jira/browse/MNT-21041
- Reference: https://github.com/helm/helm/issues/2639
