### PR TITLE
MNT-21042: ACS Helm upgrade fails to perform rolling update with zero downtime

### DIFF
--- a/helm/alfresco-search/Chart.yaml
+++ b/helm/alfresco-search/Chart.yaml
@@ -11,4 +11,4 @@ keywords:
 name: alfresco-search
 sources:
 - https://github.com/alfresco/alfresco-search-deployment
-version: 1.0.2
+version: 1.0.3

--- a/helm/alfresco-search/requirements.yaml
+++ b/helm/alfresco-search/requirements.yaml
@@ -1,6 +1,6 @@
 # Alfresco Insight Engine brings Alfresco Insight Zeppelin
 dependencies:
 - name: alfresco-insight-zeppelin
-  version: 1.0.2
+  version: 1.0.3
   repository: http://kubernetes-charts.alfresco.com/stable
   condition: alfresco-insight-zeppelin.enabled

--- a/helm/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-search/templates/deployment.yaml
@@ -11,6 +11,11 @@ metadata:
     component: search
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}
   template:
     metadata:
       annotations:
@@ -62,6 +67,11 @@ spec:
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          # sleep to drain any existing connections
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 10"]
       initContainers:
         - name: init-db
           image: busybox


### PR DESCRIPTION
- Add deployment template with k8s annotation `strategy` for `rollingUpdate` with sensible defaults and bump zepplin version that include similar changes