### PR TITLE
MNT-21042: ACS Helm upgrade fails to perform rolling update with zero downtime

### DIFF
--- a/helm/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-search/templates/deployment.yaml
@@ -14,8 +14,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-search/values.yaml
+++ b/helm/alfresco-search/values.yaml
@@ -72,7 +72,10 @@ livenessProbe:
 # Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s)
 global:
   alfrescoRegistryPullSecrets: quay-registry-secret
-
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 # Define Affinity and Tolerations used for scheduling SOLR on Pod and PV level
 
 # affinity: |


### PR DESCRIPTION
- Make `rollingUpgrade` parameters as `global` values so it can inherit from it's parent helm chart (ex: ACS helm chart)